### PR TITLE
Track expert queries

### DIFF
--- a/imitation_learning/bc.py
+++ b/imitation_learning/bc.py
@@ -52,12 +52,14 @@ def bc(seed, agent, expert, env, start_pose, observation_shape, downsampling_met
 
     dataset = Dataset()
 
-    log = {'Number of Samples': [], 
-           'Number of Expert Queries': [], 
+    log = {'Number of Samples': [],
+           'Number of Expert Queries': [],
            'Mean Distance Travelled': [],
            'STDEV Distance Travelled': [],
            'Mean Reward': [],
            'STDEV Reward': []}
+
+    num_of_expert_queries = 0
 
     # Perform BC
     for iter in range(n_iter + 1):
@@ -145,6 +147,7 @@ def bc(seed, agent, expert, env, start_pose, observation_shape, downsampling_met
 
             speed, steer = expert.plan(obs['poses_x'][0], obs['poses_y'][0], obs['poses_theta'][0], tlad, vgain)
             action = np.array([[steer, speed]])
+            num_of_expert_queries += 1
 
             obs, step_reward, done, info = env.step(action)
 
@@ -178,7 +181,7 @@ def bc(seed, agent, expert, env, start_pose, observation_shape, downsampling_met
         dataset.add(traj)
 
         log['Number of Samples'].append(dataset.get_num_of_total_samples())
-        log['Number of Expert Queries'].append(dataset.get_num_of_total_samples())
+        log['Number of Expert Queries'].append(num_of_expert_queries)
 
 
         # Train the agent

--- a/imitation_learning/hg_dagger.py
+++ b/imitation_learning/hg_dagger.py
@@ -109,6 +109,7 @@ def hg_dagger(seed, agent, expert, env, start_pose, observation_shape, downsampl
         if iter == 0:
             # Bootstrap using BC
             agent, log, dataset = bc(seed, agent, expert, env, start_pose, observation_shape, downsampling_method, render, render_mode, purpose='bootstrap')
+            num_of_expert_queries = log['Number of Expert Queries'][-1]
         else:
             # Reset environment
             done = False
@@ -155,6 +156,7 @@ def hg_dagger(seed, agent, expert, env, start_pose, observation_shape, downsampl
                     curr_action = np.array([[curr_expert_steer, curr_expert_speed]])
                     """
                     curr_action = expert_action
+                    num_of_expert_queries += 1
 
                     traj["observs"].append(observ)
                     traj["scans"].append(downsampled_scan)
@@ -190,7 +192,7 @@ def hg_dagger(seed, agent, expert, env, start_pose, observation_shape, downsampl
                 dataset.add(traj)
 
             log['Number of Samples'].append(dataset.get_num_of_total_samples())
-            log['Number of Expert Queries'].append(dataset.get_num_of_total_samples())
+            log['Number of Expert Queries'].append(num_of_expert_queries)
 
             print("Training agent...")
             for _ in range(n_batch_updates_per_iter):


### PR DESCRIPTION
## Summary
- increment expert query counter in BC and HG-DAgger
- log expert query counts after each rollout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842a059e3a0832d979816f7a1d7a0cd